### PR TITLE
Keyboard methods to simplify adding event listeners

### DIFF
--- a/src/main/java/org/academiadecodigo/simplegraphics/keyboard/Keyboard.java
+++ b/src/main/java/org/academiadecodigo/simplegraphics/keyboard/Keyboard.java
@@ -7,6 +7,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Iterator;
 
+import static org.academiadecodigo.simplegraphics.keyboard.KeyboardEventType.KEY_PRESSED;
+import static org.academiadecodigo.simplegraphics.keyboard.KeyboardEventType.KEY_RELEASED;
+
 /**
  * Instantiate a Keyboard for obtaining key handling capability
  */
@@ -47,6 +50,19 @@ public class Keyboard implements KeyListener {
         e.setKey(key);
         e.setKeyboardEventType(type);
         addEventListener(e);
+    }
+
+    /**
+     * Add Keyboard event listeners to a group of keys
+     * @see KeyboardEvent
+     * @param keys the key codes
+     * @see KeyboardEventType
+     * @param type the event to add
+     */
+    public void addEventListeners(int[] keys, KeyboardEventType type) {
+        for (int key : keys) {
+            addEventListener(key, type);
+        }
     }
 
     /**

--- a/src/main/java/org/academiadecodigo/simplegraphics/keyboard/Keyboard.java
+++ b/src/main/java/org/academiadecodigo/simplegraphics/keyboard/Keyboard.java
@@ -36,6 +36,20 @@ public class Keyboard implements KeyListener {
     }
 
     /**
+     * Add a new Keyboard event listener
+     * @see KeyboardEvent
+     * @param key the associated key code
+     * @see KeyboardEventType
+     * @param type the event to add
+     */
+    public void addEventListener(int key, KeyboardEventType type) {
+        KeyboardEvent e = new KeyboardEvent();
+        e.setKey(key);
+        e.setKeyboardEventType(type);
+        addEventListener(e);
+    }
+
+    /**
      * Remove an existing Keyboard event listener
      * @param keyboardEvent the event to remove
      */

--- a/src/test/java/org/academiadecodigo/simplegraphics/test/Tester.java
+++ b/src/test/java/org/academiadecodigo/simplegraphics/test/Tester.java
@@ -28,6 +28,7 @@ public class Tester implements KeyboardHandler, MouseHandler {
         k.addEventListener(event);
 
         k.addEventListener(KeyboardEvent.KEY_ENTER, KeyboardEventType.KEY_PRESSED);
+        k.addEventListeners(new int[]{KeyboardEvent.KEY_ESC, KeyboardEvent.KEY_Q}, KeyboardEventType.KEY_PRESSED);
 
         Mouse m = new Mouse(this);
 
@@ -83,6 +84,12 @@ public class Tester implements KeyboardHandler, MouseHandler {
                 break;
             case KeyboardEvent.KEY_ENTER:
                 System.out.println("ENTER WAS PRESSED");
+                break;
+            case KeyboardEvent.KEY_ESC:
+                System.out.println("ESC WAS PRESSED");
+                break;
+            case KeyboardEvent.KEY_Q:
+                System.out.println("Q WAS PRESSED");
                 break;
         }
 

--- a/src/test/java/org/academiadecodigo/simplegraphics/test/Tester.java
+++ b/src/test/java/org/academiadecodigo/simplegraphics/test/Tester.java
@@ -27,6 +27,8 @@ public class Tester implements KeyboardHandler, MouseHandler {
         event.setKeyboardEventType(KeyboardEventType.KEY_PRESSED);
         k.addEventListener(event);
 
+        k.addEventListener(KeyboardEvent.KEY_ENTER, KeyboardEventType.KEY_PRESSED);
+
         Mouse m = new Mouse(this);
 
         Rectangle rect = new Rectangle(10, 10, 400, 400);
@@ -75,7 +77,14 @@ public class Tester implements KeyboardHandler, MouseHandler {
 
     @Override
     public void keyPressed(KeyboardEvent e) {
-        System.out.println("SPACE KEY PRESSED");
+        switch (e.getKey()){
+            case KeyboardEvent.KEY_SPACE:
+                System.out.println("SPACE KEY PRESSED");
+                break;
+            case KeyboardEvent.KEY_ENTER:
+                System.out.println("ENTER WAS PRESSED");
+                break;
+        }
 
     }
 


### PR DESCRIPTION
Proposal to simplify Keyboard API when adding event listeners by adding:

- **addEventListener(int key, KeyboardEventType type)** method overload 

- **addEventListeners(int[] keys, KeyboardEventType type)**

These methods encapsulate the keyboard events instantiation and the submission of the associated event listeners. Program only needs to specify the key code and the it the type is pressed or released.